### PR TITLE
Add serde Serialize and Deserialize implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ maintenance = { status = "actively-developed" }
 travis-ci = { repository = "dunmatt/no-std-net" }
 
 [dependencies]
+serde = { version = "1.0.104", default-features = false, optional = true }
+
+[dev-dependencies]
+serde_test = "1.0.104"
 
 [dependencies.byteorder]
 default-features = false

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,0 +1,260 @@
+use addr::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use core::{fmt, str};
+use ip::{IpAddr, Ipv4Addr, Ipv6Addr};
+use serde::de::{Deserialize, Deserializer, EnumAccess, Error, Unexpected, VariantAccess, Visitor};
+
+macro_rules! variant_identifier {
+    (
+        $name_kind: ident ( $($variant: ident; $bytes: expr; $index: expr),* )
+        $expecting_message: expr,
+        $variants_name: ident
+    ) => {
+        enum $name_kind {
+            $( $variant ),*
+        }
+
+        static $variants_name: &'static [&'static str] = &[ $( stringify!($variant) ),*];
+
+        impl<'de> Deserialize<'de> for $name_kind {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct KindVisitor;
+
+                impl<'de> Visitor<'de> for KindVisitor {
+                    type Value = $name_kind;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str($expecting_message)
+                    }
+
+                    fn visit_u32<E>(self, value: u32) -> Result<Self::Value, E>
+                    where
+                        E: Error,
+                    {
+                        match value {
+                            $(
+                                $index => Ok($name_kind :: $variant),
+                            )*
+                            _ => Err(Error::invalid_value(Unexpected::Unsigned(value as u64), &self),),
+                        }
+                    }
+
+                    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                    where
+                        E: Error,
+                    {
+                        match value {
+                            $(
+                                stringify!($variant) => Ok($name_kind :: $variant),
+                            )*
+                            _ => Err(Error::unknown_variant(value, $variants_name)),
+                        }
+                    }
+
+                    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+                    where
+                        E: Error,
+                    {
+                        match value {
+                            $(
+                                $bytes => Ok($name_kind :: $variant),
+                            )*
+                            _ => {
+                                match str::from_utf8(value) {
+                                    Ok(value) => Err(Error::unknown_variant(value, $variants_name)),
+                                    Err(_) => Err(Error::invalid_value(Unexpected::Bytes(value), &self)),
+                                }
+                            }
+                        }
+                    }
+                }
+
+                deserializer.deserialize_identifier(KindVisitor)
+            }
+        }
+    }
+}
+
+macro_rules! deserialize_enum {
+    (
+        $name: ident $name_kind: ident ( $($variant: ident; $bytes: expr; $index: expr),* )
+        $expecting_message: expr,
+        $deserializer: expr
+    ) => {
+        variant_identifier!{
+            $name_kind ( $($variant; $bytes; $index),* )
+            $expecting_message,
+            VARIANTS
+        }
+
+        struct EnumVisitor;
+        impl<'de> Visitor<'de> for EnumVisitor {
+            type Value = $name;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str(concat!("a ", stringify!($name)))
+            }
+
+
+            fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+            where
+                A: EnumAccess<'de>,
+            {
+                match data.variant()? {
+                    $(
+                        ($name_kind :: $variant, v) => v.newtype_variant().map($name :: $variant),
+                    )*
+                }
+            }
+        }
+        $deserializer.deserialize_enum(stringify!($name), VARIANTS, EnumVisitor)
+    }
+}
+
+macro_rules! parse_ip_impl {
+    ($expecting:tt $ty:ty; $size:tt) => {
+        impl<'de> Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                if deserializer.is_human_readable() {
+                    struct IpAddrVisitor;
+
+                    impl<'de> Visitor<'de> for IpAddrVisitor {
+                        type Value = $ty;
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str($expecting)
+                        }
+
+                        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                        where
+                            E: Error,
+                        {
+                            s.parse().map_err(Error::custom)
+                        }
+                    }
+
+                    deserializer.deserialize_str(IpAddrVisitor)
+                } else {
+                    <[u8; $size]>::deserialize(deserializer).map(<$ty>::from)
+                }
+            }
+        }
+    };
+}
+
+impl<'de> Deserialize<'de> for IpAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            struct IpAddrVisitor;
+
+            impl<'de> Visitor<'de> for IpAddrVisitor {
+                type Value = IpAddr;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("IP address")
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    s.parse().map_err(Error::custom)
+                }
+            }
+
+            deserializer.deserialize_str(IpAddrVisitor)
+        } else {
+            deserialize_enum! {
+                IpAddr IpAddrKind (V4; b"V4"; 0, V6; b"V6"; 1)
+                "`V4` or `V6`",
+                deserializer
+            }
+        }
+    }
+}
+
+parse_ip_impl!("IPv4 address" Ipv4Addr; 4);
+parse_ip_impl!("IPv6 address" Ipv6Addr; 16);
+
+macro_rules! parse_socket_impl {
+    ($expecting:tt $ty:ty, $new:expr) => {
+        impl<'de> Deserialize<'de> for $ty {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                if deserializer.is_human_readable() {
+                    struct SocketAddrVisitor;
+
+                    impl<'de> Visitor<'de> for SocketAddrVisitor {
+                        type Value = $ty;
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str($expecting)
+                        }
+
+                        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                        where
+                            E: Error,
+                        {
+                            s.parse().map_err(Error::custom)
+                        }
+                    }
+
+                    deserializer.deserialize_str(SocketAddrVisitor)
+                } else {
+                    <(_, u16)>::deserialize(deserializer).map(|(ip, port)| $new(ip, port))
+                }
+            }
+        }
+    };
+}
+
+impl<'de> Deserialize<'de> for SocketAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            struct SocketAddrVisitor;
+
+            impl<'de> Visitor<'de> for SocketAddrVisitor {
+                type Value = SocketAddr;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    formatter.write_str("socket address")
+                }
+
+                fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+                where
+                    E: Error,
+                {
+                    s.parse().map_err(Error::custom)
+                }
+            }
+
+            deserializer.deserialize_str(SocketAddrVisitor)
+        } else {
+            deserialize_enum! {
+                SocketAddr SocketAddrKind (V4; b"V4"; 0, V6; b"V6"; 1)
+                "`V4` or `V6`",
+                deserializer
+            }
+        }
+    }
+}
+
+parse_socket_impl!("IPv4 socket address" SocketAddrV4, SocketAddrV4::new);
+parse_socket_impl!("IPv6 socket address" SocketAddrV6, |ip, port| SocketAddrV6::new(
+    ip, port, 0, 0
+));
+
+// Note: `::ser::tests` tests both serializing and deserializing tokens

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -4,7 +4,7 @@
 
 use core::cmp::Ordering;
 
-use byteorder::{ ByteOrder, NetworkEndian };
+use byteorder::{ByteOrder, NetworkEndian};
 
 // TODO: copy the parsers over from https://github.com/rust-lang/rust/blob/master/src/libstd/net/parser.rs
 // and update all the tests
@@ -116,9 +116,8 @@ pub enum Ipv6MulticastScope {
     AdminLocal,
     SiteLocal,
     OrganizationLocal,
-    Global
+    Global,
 }
-
 
 impl IpAddr {
     /// Returns [`true`] for the special 'unspecified' address.
@@ -305,13 +304,182 @@ impl ::fmt::Display for IpAddr {
     }
 }
 
+impl From<[u8; 4]> for Ipv4Addr {
+    /// Creates an `Ipv4Addr` from a four element byte array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::Ipv4Addr;
+    ///
+    /// let addr = Ipv4Addr::from([13u8, 12u8, 11u8, 10u8]);
+    /// assert_eq!(Ipv4Addr::new(13, 12, 11, 10), addr);
+    /// ```
+    fn from(octets: [u8; 4]) -> Ipv4Addr {
+        Ipv4Addr::new(octets[0], octets[1], octets[2], octets[3])
+    }
+}
+
+impl From<[u8; 4]> for IpAddr {
+    /// Creates an `IpAddr::V4` from a four element byte array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::{IpAddr, Ipv4Addr};
+    ///
+    /// let addr = IpAddr::from([13u8, 12u8, 11u8, 10u8]);
+    /// assert_eq!(IpAddr::V4(Ipv4Addr::new(13, 12, 11, 10)), addr);
+    /// ```
+    fn from(octets: [u8; 4]) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::from(octets))
+    }
+}
+
+impl From<[u8; 16]> for Ipv6Addr {
+    /// Creates an `Ipv6Addr` from a sixteen element byte array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::from([
+    ///     25u8, 24u8, 23u8, 22u8, 21u8, 20u8, 19u8, 18u8,
+    ///     17u8, 16u8, 15u8, 14u8, 13u8, 12u8, 11u8, 10u8,
+    /// ]);
+    /// assert_eq!(
+    ///     Ipv6Addr::new(
+    ///         0x1918, 0x1716,
+    ///         0x1514, 0x1312,
+    ///         0x1110, 0x0f0e,
+    ///         0x0d0c, 0x0b0a
+    ///     ),
+    ///     addr
+    /// );
+    /// ```
+    fn from(octets: [u8; 16]) -> Ipv6Addr {
+        Ipv6Addr { inner: octets }
+    }
+}
+
+impl From<[u16; 8]> for Ipv6Addr {
+    /// Creates an `Ipv6Addr` from an eight element 16-bit array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::from([
+    ///     525u16, 524u16, 523u16, 522u16,
+    ///     521u16, 520u16, 519u16, 518u16,
+    /// ]);
+    /// assert_eq!(
+    ///     Ipv6Addr::new(
+    ///         0x20d, 0x20c,
+    ///         0x20b, 0x20a,
+    ///         0x209, 0x208,
+    ///         0x207, 0x206
+    ///     ),
+    ///     addr
+    /// );
+    /// ```
+    fn from(segments: [u16; 8]) -> Ipv6Addr {
+        let [a, b, c, d, e, f, g, h] = segments;
+        Ipv6Addr::new(a, b, c, d, e, f, g, h)
+    }
+}
+
+impl From<[u8; 16]> for IpAddr {
+    /// Creates an `IpAddr::V6` from a sixteen element byte array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::{IpAddr, Ipv6Addr};
+    ///
+    /// let addr = IpAddr::from([
+    ///     25u8, 24u8, 23u8, 22u8, 21u8, 20u8, 19u8, 18u8,
+    ///     17u8, 16u8, 15u8, 14u8, 13u8, 12u8, 11u8, 10u8,
+    /// ]);
+    /// assert_eq!(
+    ///     IpAddr::V6(Ipv6Addr::new(
+    ///         0x1918, 0x1716,
+    ///         0x1514, 0x1312,
+    ///         0x1110, 0x0f0e,
+    ///         0x0d0c, 0x0b0a
+    ///     )),
+    ///     addr
+    /// );
+    /// ```
+    fn from(octets: [u8; 16]) -> IpAddr {
+        IpAddr::V6(Ipv6Addr::from(octets))
+    }
+}
+
+impl From<[u16; 8]> for IpAddr {
+    /// Creates an `IpAddr::V6` from an eight element 16-bit array.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::{IpAddr, Ipv6Addr};
+    ///
+    /// let addr = IpAddr::from([
+    ///     525u16, 524u16, 523u16, 522u16,
+    ///     521u16, 520u16, 519u16, 518u16,
+    /// ]);
+    /// assert_eq!(
+    ///     IpAddr::V6(Ipv6Addr::new(
+    ///         0x20d, 0x20c,
+    ///         0x20b, 0x20a,
+    ///         0x209, 0x208,
+    ///         0x207, 0x206
+    ///     )),
+    ///     addr
+    /// );
+    /// ```
+    fn from(segments: [u16; 8]) -> IpAddr {
+        IpAddr::V6(Ipv6Addr::from(segments))
+    }
+}
+
 impl From<Ipv4Addr> for IpAddr {
+    /// Copies this address to a new `IpAddr::V4`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::{IpAddr, Ipv4Addr};
+    ///
+    /// let addr = Ipv4Addr::new(127, 0, 0, 1);
+    ///
+    /// assert_eq!(
+    ///     IpAddr::V4(addr),
+    ///     IpAddr::from(addr)
+    /// )
+    /// ```
     fn from(ipv4: Ipv4Addr) -> IpAddr {
         IpAddr::V4(ipv4)
     }
 }
 
 impl From<Ipv6Addr> for IpAddr {
+    /// Copies this address to a new `IpAddr::V6`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::{IpAddr, Ipv6Addr};
+    ///
+    /// let addr = Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2ff);
+    ///
+    /// assert_eq!(
+    ///     IpAddr::V6(addr),
+    ///     IpAddr::from(addr)
+    /// );
+    /// ```
     fn from(ipv6: Ipv6Addr) -> IpAddr {
         IpAddr::V6(ipv6)
     }
@@ -445,7 +613,7 @@ impl Ipv4Addr {
             (10, _) => true,
             (172, b) if 16 <= b && b <= 31 => true,
             (192, 168) => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -498,8 +666,12 @@ impl Ipv4Addr {
     /// }
     /// ```
     pub fn is_global(&self) -> bool {
-        !self.is_private() && !self.is_loopback() && !self.is_link_local() &&
-        !self.is_broadcast() && !self.is_documentation() && !self.is_unspecified()
+        !self.is_private()
+            && !self.is_loopback()
+            && !self.is_link_local()
+            && !self.is_broadcast()
+            && !self.is_documentation()
+            && !self.is_unspecified()
     }
 
     /// Returns [`true`] if this is a multicast address (224.0.0.0/4).
@@ -568,7 +740,7 @@ impl Ipv4Addr {
             (192, 0, 2) => true,
             (198, 51, 100) => true,
             (203, 0, 113) => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -587,9 +759,16 @@ impl Ipv4Addr {
     ///            Ipv6Addr::new(0, 0, 0, 0, 0, 0, 49152, 767));
     /// ```
     pub fn to_ipv6_compatible(&self) -> Ipv6Addr {
-        Ipv6Addr::new(0, 0, 0, 0, 0, 0,
-                      ((self.inner[0] as u16) << 8) | self.inner[1] as u16,
-                      ((self.inner[2] as u16) << 8) | self.inner[3] as u16)
+        Ipv6Addr::new(
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            ((self.inner[0] as u16) << 8) | self.inner[1] as u16,
+            ((self.inner[2] as u16) << 8) | self.inner[3] as u16,
+        )
     }
 
     /// Converts this address to an IPv4-mapped [IPv6 address].
@@ -607,15 +786,26 @@ impl Ipv4Addr {
     ///            Ipv6Addr::new(0, 0, 0, 0, 0, 65535, 49152, 767));
     /// ```
     pub fn to_ipv6_mapped(&self) -> Ipv6Addr {
-        Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff,
-                      ((self.inner[0] as u16) << 8) | self.inner[1] as u16,
-                      ((self.inner[2] as u16) << 8) | self.inner[3] as u16)
+        Ipv6Addr::new(
+            0,
+            0,
+            0,
+            0,
+            0,
+            0xffff,
+            ((self.inner[0] as u16) << 8) | self.inner[1] as u16,
+            ((self.inner[2] as u16) << 8) | self.inner[3] as u16,
+        )
     }
 }
 
 impl ::fmt::Display for Ipv4Addr {
     fn fmt(&self, fmt: &mut ::fmt::Formatter) -> ::fmt::Result {
-        write!(fmt, "{}.{}.{}.{}", self.inner[0], self.inner[1], self.inner[2], self.inner[3])
+        write!(
+            fmt,
+            "{}.{}.{}.{}",
+            self.inner[0], self.inner[1], self.inner[2], self.inner[3]
+        )
     }
 }
 
@@ -689,14 +879,24 @@ impl Ipv6Addr {
     /// ```
     pub fn new(a: u16, b: u16, c: u16, d: u16, e: u16, f: u16, g: u16, h: u16) -> Ipv6Addr {
         Ipv6Addr {
-            inner: [(a >> 8) as u8, a as u8,
-                    (b >> 8) as u8, b as u8,
-                    (c >> 8) as u8, c as u8,
-                    (d >> 8) as u8, d as u8,
-                    (e >> 8) as u8, e as u8,
-                    (f >> 8) as u8, f as u8,
-                    (g >> 8) as u8, g as u8,
-                    (h >> 8) as u8, h as u8],
+            inner: [
+                (a >> 8) as u8,
+                a as u8,
+                (b >> 8) as u8,
+                b as u8,
+                (c >> 8) as u8,
+                c as u8,
+                (d >> 8) as u8,
+                d as u8,
+                (e >> 8) as u8,
+                e as u8,
+                (f >> 8) as u8,
+                f as u8,
+                (g >> 8) as u8,
+                g as u8,
+                (h >> 8) as u8,
+                h as u8,
+            ],
         }
     }
 
@@ -842,7 +1042,7 @@ impl Ipv6Addr {
         match self.multicast_scope() {
             Some(Ipv6MulticastScope::Global) => true,
             None => self.is_unicast_global(),
-            _ => false
+            _ => false,
         }
     }
 
@@ -958,9 +1158,13 @@ impl Ipv6Addr {
     /// }
     /// ```
     pub fn is_unicast_global(&self) -> bool {
-        !self.is_multicast() && !self.is_loopback() && !self.is_unicast_link_local()
-            && !self.is_unicast_site_local() && !self.is_unique_local()
-            && !self.is_unspecified() && !self.is_documentation()
+        !self.is_multicast()
+            && !self.is_loopback()
+            && !self.is_unicast_link_local()
+            && !self.is_unicast_site_local()
+            && !self.is_unique_local()
+            && !self.is_unspecified()
+            && !self.is_documentation()
     }
 
     /// Returns the address's multicast scope if the address is multicast.
@@ -986,7 +1190,7 @@ impl Ipv6Addr {
                 5 => Some(Ipv6MulticastScope::SiteLocal),
                 8 => Some(Ipv6MulticastScope::OrganizationLocal),
                 14 => Some(Ipv6MulticastScope::Global),
-                _ => None
+                _ => None,
             }
         } else {
             None
@@ -1033,11 +1237,13 @@ impl Ipv6Addr {
     /// ```
     pub fn to_ipv4(&self) -> Option<Ipv4Addr> {
         match self.segments() {
-            [0, 0, 0, 0, 0, f, g, h] if f == 0 || f == 0xffff => {
-                Some(Ipv4Addr::new((g >> 8) as u8, g as u8,
-                                   (h >> 8) as u8, h as u8))
-            },
-            _ => None
+            [0, 0, 0, 0, 0, f, g, h] if f == 0 || f == 0xffff => Some(Ipv4Addr::new(
+                (g >> 8) as u8,
+                g as u8,
+                (h >> 8) as u8,
+                h as u8,
+            )),
+            _ => None,
         }
     }
 
@@ -1062,15 +1268,23 @@ impl ::fmt::Display for Ipv6Addr {
             [0, 0, 0, 0, 0, 0, 0, 0] => write!(fmt, "::"),
             [0, 0, 0, 0, 0, 0, 0, 1] => write!(fmt, "::1"),
             // Ipv4 Compatible address
-            [0, 0, 0, 0, 0, 0, g, h] => {
-                write!(fmt, "::{}.{}.{}.{}", (g >> 8) as u8, g as u8,
-                       (h >> 8) as u8, h as u8)
-            }
+            [0, 0, 0, 0, 0, 0, g, h] => write!(
+                fmt,
+                "::{}.{}.{}.{}",
+                (g >> 8) as u8,
+                g as u8,
+                (h >> 8) as u8,
+                h as u8
+            ),
             // Ipv4-Mapped address
-            [0, 0, 0, 0, 0, 0xffff, g, h] => {
-                write!(fmt, "::ffff:{}.{}.{}.{}", (g >> 8) as u8, g as u8,
-                       (h >> 8) as u8, h as u8)
-            },
+            [0, 0, 0, 0, 0, 0xffff, g, h] => write!(
+                fmt,
+                "::ffff:{}.{}.{}.{}",
+                (g >> 8) as u8,
+                g as u8,
+                (h >> 8) as u8,
+                h as u8
+            ),
             _ => {
                 fn find_zero_slice(segments: &[u16; 8]) -> (usize, usize) {
                     let mut longest_span_len = 0;
@@ -1117,8 +1331,11 @@ impl ::fmt::Display for Ipv6Addr {
                     fmt_subslice(&self.segments()[zeros_at + zeros_len..], fmt)
                 } else {
                     let &[a, b, c, d, e, f, g, h] = &self.segments();
-                    write!(fmt, "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}",
-                           a, b, c, d, e, f, g, h)
+                    write!(
+                        fmt,
+                        "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}:{:x}",
+                        a, b, c, d, e, f, g, h
+                    )
                 }
             }
         }
@@ -1169,6 +1386,19 @@ impl PartialOrd<IpAddr> for Ipv6Addr {
 
 #[cfg(feature = "i128")]
 impl From<Ipv6Addr> for u128 {
+    /// Convert an `Ipv6Addr` into a host byte order `u128`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::new(
+    ///     0x1020, 0x3040, 0x5060, 0x7080,
+    ///     0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+    /// );
+    /// assert_eq!(0x102030405060708090A0B0C0D0E0F00D_u128, u128::from(addr));
+    /// ```
     fn from(ip: Ipv6Addr) -> u128 {
         NetworkEndian::read_u128(&ip.inner)
     }
@@ -1176,6 +1406,21 @@ impl From<Ipv6Addr> for u128 {
 
 #[cfg(feature = "i128")]
 impl From<u128> for Ipv6Addr {
+    /// Convert a host byte order `u128` into an `Ipv6Addr`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use no_std_net::Ipv6Addr;
+    ///
+    /// let addr = Ipv6Addr::from(0x102030405060708090A0B0C0D0E0F00D_u128);
+    /// assert_eq!(
+    ///     Ipv6Addr::new(
+    ///         0x1020, 0x3040, 0x5060, 0x7080,
+    ///         0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+    ///     ),
+    ///     addr);
+    /// ```
     fn from(ip: u128) -> Ipv6Addr {
         let mut res = Ipv6Addr::localhost();
         NetworkEndian::write_u128(&mut res.inner, ip);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,5 +56,13 @@ mod addr;
 mod ip;
 mod parser;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+#[cfg(feature = "serde")]
+mod de;
+#[cfg(feature = "serde")]
+mod ser;
+
+
 pub use addr::{ SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs };
 pub use ip::{ IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope };

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,439 @@
+use serde::ser::{Error, Serialize, Serializer};
+
+use addr::{SocketAddr, SocketAddrV4, SocketAddrV6};
+use ip::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use core::fmt::{self, write, Write};
+
+struct Wrapper<'a> {
+    buf: &'a mut [u8],
+    offset: usize,
+}
+
+impl<'a> Wrapper<'a> {
+    fn new(buf: &'a mut [u8]) -> Self {
+        Wrapper { buf, offset: 0 }
+    }
+
+    pub fn as_str(self) -> Option<&'a str> {
+        if self.offset <= self.buf.len() {
+            match core::str::from_utf8(&self.buf[..self.offset]) {
+                Ok(s) => Some(s),
+                Err(_) => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> Write for Wrapper<'a> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if self.offset > self.buf.len() {
+            return Err(fmt::Error);
+        }
+        let remaining_buf = &mut self.buf[self.offset..];
+        let raw_s = s.as_bytes();
+        let write_num = core::cmp::min(raw_s.len(), remaining_buf.len());
+        remaining_buf[..write_num].copy_from_slice(&raw_s[..write_num]);
+        self.offset += raw_s.len();
+        if write_num < raw_s.len() {
+            Err(fmt::Error)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+macro_rules! serialize_display_bounded_length {
+    ($value:expr, $max:expr, $serializer:expr) => {{
+        let mut buffer: [u8; $max] = [0u8; $max];
+        let mut w = Wrapper::new(&mut buffer);
+        write(&mut w, format_args!("{}", $value)).map_err(Error::custom)?;
+        if let Some(s) = w.as_str() {
+            $serializer.serialize_str(s)
+        } else {
+            Err(Error::custom("Failed to parse str to UTF8"))
+        }
+    }};
+}
+
+impl Serialize for IpAddr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            match *self {
+                IpAddr::V4(ref a) => a.serialize(serializer),
+                IpAddr::V6(ref a) => a.serialize(serializer),
+            }
+        } else {
+            match *self {
+                IpAddr::V4(ref a) => serializer.serialize_newtype_variant("IpAddr", 0, "V4", a),
+                IpAddr::V6(ref a) => serializer.serialize_newtype_variant("IpAddr", 1, "V6", a),
+            }
+        }
+    }
+}
+
+impl Serialize for Ipv4Addr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        S::Error: Error,
+    {
+        if serializer.is_human_readable() {
+            const MAX_LEN: usize = 15;
+            debug_assert_eq!(MAX_LEN, "101.102.103.104".len());
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            self.octets().serialize(serializer)
+        }
+    }
+}
+
+impl Serialize for Ipv6Addr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        S::Error: Error,
+    {
+        if serializer.is_human_readable() {
+            const MAX_LEN: usize = 39;
+            debug_assert_eq!(MAX_LEN, "1001:1002:1003:1004:1005:1006:1007:1008".len());
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            self.octets().serialize(serializer)
+        }
+    }
+}
+
+impl Serialize for SocketAddr {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            match *self {
+                SocketAddr::V4(ref addr) => addr.serialize(serializer),
+                SocketAddr::V6(ref addr) => addr.serialize(serializer),
+            }
+        } else {
+            match *self {
+                SocketAddr::V4(ref addr) => {
+                    serializer.serialize_newtype_variant("SocketAddr", 0, "V4", addr)
+                }
+                SocketAddr::V6(ref addr) => {
+                    serializer.serialize_newtype_variant("SocketAddr", 1, "V6", addr)
+                }
+            }
+        }
+    }
+}
+
+impl Serialize for SocketAddrV4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        S::Error: Error,
+    {
+        if serializer.is_human_readable() {
+            const MAX_LEN: usize = 21;
+            debug_assert_eq!(MAX_LEN, "101.102.103.104:65000".len());
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            (self.ip(), self.port()).serialize(serializer)
+        }
+    }
+}
+
+impl Serialize for SocketAddrV6 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        S::Error: Error,
+    {
+        if serializer.is_human_readable() {
+            const MAX_LEN: usize = 47;
+            debug_assert_eq!(
+                MAX_LEN,
+                "[1001:1002:1003:1004:1005:1006:1007:1008]:65000".len()
+            );
+            serialize_display_bounded_length!(self, MAX_LEN, serializer)
+        } else {
+            (self.ip(), self.port()).serialize(serializer)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate serde_test;
+    use self::serde_test::{assert_tokens, Configure, Token};
+    use super::*;
+
+    #[test]
+    fn serialize_ipv4() {
+        assert_tokens(
+            &Ipv4Addr::new(101, 102, 103, 104).readable(),
+            &[Token::Str("101.102.103.104")],
+        );
+        assert_tokens(
+            &Ipv4Addr::new(101, 102, 103, 104).compact(),
+            &[
+                Token::Tuple { len: 4 },
+                Token::U8(101),
+                Token::U8(102),
+                Token::U8(103),
+                Token::U8(104),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_ipaddr_v4() {
+        assert_tokens(
+            &IpAddr::V4(Ipv4Addr::new(101, 102, 103, 104)).readable(),
+            &[Token::Str("101.102.103.104")],
+        );
+        assert_tokens(
+            &Ipv4Addr::new(101, 102, 103, 104).compact(),
+            &[
+                Token::Tuple { len: 4 },
+                Token::U8(101),
+                Token::U8(102),
+                Token::U8(103),
+                Token::U8(104),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_ipaddr_v6() {
+        assert_tokens(
+            &IpAddr::V6(Ipv6Addr::new(
+                0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+            ))
+            .readable(),
+            &[Token::Str("1020:3040:5060:7080:90a0:b0c0:d0e0:f00d")],
+        );
+        assert_tokens(
+            &IpAddr::V6(Ipv6Addr::new(
+                0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+            ))
+            .compact(),
+            &[
+                Token::NewtypeVariant {
+                    name: "IpAddr",
+                    variant: "V6",
+                },
+                Token::Tuple { len: 16 },
+                Token::U8(16),
+                Token::U8(32),
+                Token::U8(48),
+                Token::U8(64),
+                Token::U8(80),
+                Token::U8(96),
+                Token::U8(112),
+                Token::U8(128),
+                Token::U8(144),
+                Token::U8(160),
+                Token::U8(176),
+                Token::U8(192),
+                Token::U8(208),
+                Token::U8(224),
+                Token::U8(240),
+                Token::U8(13),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_ipv6() {
+        assert_tokens(
+            &Ipv6Addr::new(
+                0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+            )
+            .readable(),
+            &[Token::Str("1020:3040:5060:7080:90a0:b0c0:d0e0:f00d")],
+        );
+        assert_tokens(
+            &Ipv6Addr::new(
+                0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+            )
+            .compact(),
+            &[
+                Token::Tuple { len: 16 },
+                Token::U8(16),
+                Token::U8(32),
+                Token::U8(48),
+                Token::U8(64),
+                Token::U8(80),
+                Token::U8(96),
+                Token::U8(112),
+                Token::U8(128),
+                Token::U8(144),
+                Token::U8(160),
+                Token::U8(176),
+                Token::U8(192),
+                Token::U8(208),
+                Token::U8(224),
+                Token::U8(240),
+                Token::U8(13),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_socketv4() {
+        assert_tokens(
+            &SocketAddrV4::new(Ipv4Addr::new(101, 102, 103, 104), 443).readable(),
+            &[Token::Str("101.102.103.104:443")],
+        );
+        assert_tokens(
+            &SocketAddrV4::new(Ipv4Addr::new(101, 102, 103, 104), 443).compact(),
+            &[
+                Token::Tuple { len: 2 },
+                Token::Tuple { len: 4 },
+                Token::U8(101),
+                Token::U8(102),
+                Token::U8(103),
+                Token::U8(104),
+                Token::TupleEnd,
+                Token::U16(443),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_socket_addr_v4() {
+        assert_tokens(
+            &SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(101, 102, 103, 104), 443)).readable(),
+            &[Token::Str("101.102.103.104:443")],
+        );
+        assert_tokens(
+            &SocketAddrV4::new(Ipv4Addr::new(101, 102, 103, 104), 443).compact(),
+            &[
+                Token::Tuple { len: 2 },
+                Token::Tuple { len: 4 },
+                Token::U8(101),
+                Token::U8(102),
+                Token::U8(103),
+                Token::U8(104),
+                Token::TupleEnd,
+                Token::U16(443),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_socket_addr_v6() {
+        assert_tokens(
+            &SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::new(
+                    0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+                ),
+                443,
+                0,
+                0,
+            ))
+            .readable(),
+            &[Token::Str("[1020:3040:5060:7080:90a0:b0c0:d0e0:f00d]:443")],
+        );
+        assert_tokens(
+            &SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::new(
+                    0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+                ),
+                443,
+                0,
+                0,
+            ))
+            .compact(),
+            &[
+                Token::NewtypeVariant {
+                    name: "SocketAddr",
+                    variant: "V6",
+                },
+                Token::Tuple { len: 2 },
+                Token::Tuple { len: 16 },
+                Token::U8(16),
+                Token::U8(32),
+                Token::U8(48),
+                Token::U8(64),
+                Token::U8(80),
+                Token::U8(96),
+                Token::U8(112),
+                Token::U8(128),
+                Token::U8(144),
+                Token::U8(160),
+                Token::U8(176),
+                Token::U8(192),
+                Token::U8(208),
+                Token::U8(224),
+                Token::U8(240),
+                Token::U8(13),
+                Token::TupleEnd,
+                Token::U16(443),
+                Token::TupleEnd,
+            ],
+        );
+    }
+
+    #[test]
+    fn serialize_socketv6() {
+        assert_tokens(
+            &SocketAddrV6::new(
+                Ipv6Addr::new(
+                    0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+                ),
+                443,
+                0,
+                0,
+            )
+            .readable(),
+            &[Token::Str("[1020:3040:5060:7080:90a0:b0c0:d0e0:f00d]:443")],
+        );
+        assert_tokens(
+            &SocketAddrV6::new(
+                Ipv6Addr::new(
+                    0x1020, 0x3040, 0x5060, 0x7080, 0x90A0, 0xB0C0, 0xD0E0, 0xF00D,
+                ),
+                443,
+                0,
+                0,
+            )
+            .compact(),
+            &[
+                Token::Tuple { len: 2 },
+                Token::Tuple { len: 16 },
+                Token::U8(16),
+                Token::U8(32),
+                Token::U8(48),
+                Token::U8(64),
+                Token::U8(80),
+                Token::U8(96),
+                Token::U8(112),
+                Token::U8(128),
+                Token::U8(144),
+                Token::U8(160),
+                Token::U8(176),
+                Token::U8(192),
+                Token::U8(208),
+                Token::U8(224),
+                Token::U8(240),
+                Token::U8(13),
+                Token::TupleEnd,
+                Token::U16(443),
+                Token::TupleEnd,
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Add serde Serialize and Deserialize implementations behind 'serde' feature flag, for IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4 & SocketAdddrV6. 

Also adds some used From<> implementations for various u8 slices.

As much is possible is a direct copy from std::net