### PR TITLE
Remove `byteorder` dependency; require Rust 1.32 or later.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,6 @@ serde = { version = "^1", default-features = false, optional = true }
 [dev-dependencies]
 serde_test = "^1"
 
-[dependencies.byteorder]
-default-features = false
-version = "^1"
-
 [features]
 default = [ ]
-i128 = [ "byteorder/i128" ]
+i128 = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,6 @@ serde_test = "^1"
 
 [features]
 default = [ ]
+
+# Deprecated. Does nothing.
 i128 = [ ]

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -4,7 +4,6 @@
 
 use core::{ iter, option, slice };
 use core::result::Result;
-// use byteorder::{ ByteOrder, NetworkEndian };
 use ::{ IpAddr, Ipv4Addr, Ipv6Addr };
 
 /// An internet socket address, either IPv4 or IPv6.

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -4,8 +4,6 @@
 
 use core::cmp::Ordering;
 
-use byteorder::{ByteOrder, NetworkEndian};
-
 // TODO: copy the parsers over from https://github.com/rust-lang/rust/blob/master/src/libstd/net/parser.rs
 // and update all the tests
 
@@ -853,15 +851,13 @@ impl PartialOrd<IpAddr> for Ipv4Addr {
 
 impl From<Ipv4Addr> for u32 {
     fn from(ip: Ipv4Addr) -> u32 {
-        NetworkEndian::read_u32(&ip.inner)
+        u32::from_be_bytes(ip.inner)
     }
 }
 
 impl From<u32> for Ipv4Addr {
     fn from(ip: u32) -> Ipv4Addr {
-        let mut res = Ipv4Addr::localhost();
-        NetworkEndian::write_u32(&mut res.inner, ip);
-        res
+        Ipv4Addr { inner: u32::to_be_bytes(ip) }
     }
 }
 
@@ -1400,7 +1396,7 @@ impl From<Ipv6Addr> for u128 {
     /// assert_eq!(0x102030405060708090A0B0C0D0E0F00D_u128, u128::from(addr));
     /// ```
     fn from(ip: Ipv6Addr) -> u128 {
-        NetworkEndian::read_u128(&ip.inner)
+        u128::from_be_bytes(ip.inner)
     }
 }
 
@@ -1422,9 +1418,7 @@ impl From<u128> for Ipv6Addr {
     ///     addr);
     /// ```
     fn from(ip: u128) -> Ipv6Addr {
-        let mut res = Ipv6Addr::localhost();
-        NetworkEndian::write_u128(&mut res.inner, ip);
-        res
+        Ipv6Addr { inner: u128::to_be_bytes(ip) }
     }
 }
 

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1380,7 +1380,6 @@ impl PartialOrd<IpAddr> for Ipv6Addr {
     }
 }
 
-#[cfg(feature = "i128")]
 impl From<Ipv6Addr> for u128 {
     /// Convert an `Ipv6Addr` into a host byte order `u128`.
     ///
@@ -1400,7 +1399,6 @@ impl From<Ipv6Addr> for u128 {
     }
 }
 
-#[cfg(feature = "i128")]
 impl From<u128> for Ipv6Addr {
     /// Convert a host byte order `u128` into an `Ipv6Addr`.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,6 @@
 )]
 #![forbid(unsafe_code)]
 
-extern crate byteorder;
-
 use core::fmt;
 
 mod addr;


### PR DESCRIPTION
`u32::{to_be_bytes, from_be_bytes}` were added in Rust 1.32:

https://doc.rust-lang.org/std/primitive.u32.html#method.from_be_bytes
https://doc.rust-lang.org/std/primitive.u32.html#method.to_be_bytes
https://doc.rust-lang.org/std/primitive.u128.html#method.from_be_bytes
https://doc.rust-lang.org/std/primitive.u128.html#method.to_be_bytes