### PR TITLE
Add pub mod AddrParseError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,4 @@ mod ser;
 
 pub use addr::{ SocketAddr, SocketAddrV4, SocketAddrV6, ToSocketAddrs };
 pub use ip::{ IpAddr, Ipv4Addr, Ipv6Addr, Ipv6MulticastScope };
+pub use parser::{ AddrParseError };


### PR DESCRIPTION
Hi，I need pub mod AddrParseError in our [Occlum](https://github.com/occlum/occlum), but mod AddrParseError is in private parser.rs. Could you make this struct AddrParseError public? I think those people who need no_std net may also need AddrParseError.