### PR TITLE
Intra-doc links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: rust
-# TODO: put stable and beta back in once slice_pattern lands in stable
 rust:
-  # - stable
-  # - beta
-  - nightly
+- stable
+- beta
+- nightly
 
 cache: cargo
+
+script:
+- cargo test --verbose
+- cargo build --features serde
+- cargo build --features std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "^1", default-features = false, optional = true }
 serde_test = "^1"
 
 [features]
-default = [ ]
-
+std = []
 # Deprecated. Does nothing.
 i128 = [ ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,15 @@
 name = "no-std-net"
 description = "Rust's std::net... without the 'std'."
 version = "0.5.0"
-authors = [ "M@ Dunlap <mattdunlap@gmail.com>" ]
-categories = [ "embedded", "network-programming", "no-std" ]
+authors = ["M@ Dunlap <mattdunlap@gmail.com>"]
+categories = [
+    "embedded",
+    "network-programming",
+    "no-std",
+]
 repository = "https://github.com/dunmatt/no-std-net"
 license = "MIT"
+readme = "README.md"
 
 [badges]
 maintenance = { status = "actively-developed" }
@@ -20,4 +25,4 @@ serde_test = "^1"
 [features]
 std = []
 # Deprecated. Does nothing.
-i128 = [ ]
+i128 = []

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -12,9 +12,7 @@ use {IpAddr, Ipv4Addr, Ipv6Addr};
 /// as possibly some version-dependent additional information. See [`SocketAddrV4`]'s and
 /// [`SocketAddrV6`]'s respective documentation for more details.
 ///
-/// [IP address]: ../../no-std-net/enum.IpAddr.html
-/// [`SocketAddrV4`]: ../../no-std-net/struct.SocketAddrV4.html
-/// [`SocketAddrV6`]: ../../no-std-net/struct.SocketAddrV6.html
+/// [IP address]: IpAddr
 ///
 /// # Examples
 ///
@@ -38,7 +36,7 @@ pub enum SocketAddr {
 impl SocketAddr {
     /// Creates a new socket address from an [IP address] and a port number.
     ///
-    /// [IP address]: ../../no-std-net/enum.IpAddr.html
+    /// [IP address]: IpAddr
     ///
     /// # Examples
     ///
@@ -131,10 +129,8 @@ impl SocketAddr {
     /// Returns [`true`] if the [IP address] in this `SocketAddr` is an
     /// [IPv4 address], and [`false`] otherwise.
     ///
-    /// [`true`]: ../../std/primitive.bool.html
-    /// [`false`]: ../../std/primitive.bool.html
-    /// [IP address]: ../../no-std-net/enum.IpAddr.html
-    /// [IPv4 address]: ../../no-std-net/enum.IpAddr.html#variant.V4
+    /// [IP address]: IpAddr
+    /// [`IPv4` address]: IpAddr::V4
     ///
     /// # Examples
     ///
@@ -157,10 +153,8 @@ impl SocketAddr {
     /// Returns [`true`] if the [IP address] in this `SocketAddr` is an
     /// [IPv6 address], and [`false`] otherwise.
     ///
-    /// [`true`]: ../../std/primitive.bool.html
-    /// [`false`]: ../../std/primitive.bool.html
-    /// [IP address]: ../../no-std-net/enum.IpAddr.html
-    /// [IPv6 address]: ../../no-std-net/enum.IpAddr.html#variant.V6
+    /// [IP address]: IpAddr
+    /// [`IPv6` address]: IpAddr::V6
     ///
     /// # Examples
     ///
@@ -190,8 +184,7 @@ impl SocketAddr {
 /// See [`SocketAddr`] for a type encompassing both IPv4 and IPv6 socket addresses.
 ///
 /// [IETF RFC 793]: https://tools.ietf.org/html/rfc793
-/// [IPv4 address]: ../../no-std-net/struct.Ipv4Addr.html
-/// [`SocketAddr`]: ../../no-std-net/enum.SocketAddr.html
+/// [`IPv4` address]: Ipv4Addr
 ///
 /// # Examples
 ///
@@ -213,7 +206,7 @@ pub struct SocketAddrV4 {
 impl SocketAddrV4 {
     /// Creates a new socket address from an [IPv4 address] and a port number.
     ///
-    /// [IPv4 address]: ../../no-std-net/struct.Ipv4Addr.html
+    /// [`IPv4` address]: Ipv4Addr
     ///
     /// # Examples
     ///
@@ -297,8 +290,7 @@ impl SocketAddrV4 {
 /// See [`SocketAddr`] for a type encompassing both IPv4 and IPv6 socket addresses.
 ///
 /// [IETF RFC 2553, Section 3.3]: https://tools.ietf.org/html/rfc2553#section-3.3
-/// [IPv6 address]: ../../no-std-net/struct.Ipv6Addr.html
-/// [`SocketAddr`]: ../../no-std-net/enum.SocketAddr.html
+/// [`IPv6` address]: Ipv6Addr
 ///
 /// # Examples
 ///
@@ -327,7 +319,7 @@ impl SocketAddrV6 {
     /// parameters, see [IETF RFC 2553, Section 3.3].
     ///
     /// [IETF RFC 2553, Section 3.3]: https://tools.ietf.org/html/rfc2553#section-3.3
-    /// [IPv6 address]: ../../no-std-net/struct.Ipv6Addr.html
+    /// [`IPv6` address]: Ipv6Addr
     ///
     /// # Examples
     ///
@@ -568,18 +560,19 @@ impl ::fmt::Debug for SocketAddrV6 {
 /// Addresses returned by the operating system that are not IP addresses are
 /// silently ignored.
 ///
-/// [`FromStr`]: ../../std/str/trait.FromStr.html
-/// [`IpAddr`]: ../../no-std-net/enum.IpAddr.html
-/// [`Ipv4Addr`]: ../../no-std-net/struct.Ipv4Addr.html
-/// [`Ipv6Addr`]: ../../no-std-net/struct.Ipv6Addr.html
-/// [`SocketAddr`]: ../../no-std-net/enum.SocketAddr.html
-/// [`SocketAddrV4`]: ../../no-std-net/struct.SocketAddrV4.html
-/// [`SocketAddrV6`]: ../../no-std-net/struct.SocketAddrV6.html
-/// [`&str`]: ../../std/primitive.str.html
-/// [`TcpStream`]: ../../no-std-net/struct.TcpStream.html
-/// [`to_socket_addrs`]: #tymethod.to_socket_addrs
-/// [`UdpSocket`]: ../../no-std-net/struct.UdpSocket.html
-/// [`u16`]: ../../std/primitive.u16.html
+/// [`FromStr`]: core::str::FromStr
+/// [`&str`]: str
+#[cfg_attr(feature = "std", doc = "[`TcpStream`]: std::net::TcpStream")]
+#[cfg_attr(
+    not(feature = "std"),
+    doc = "[`TcpStream`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html"
+)]
+/// [`to_socket_addrs`]: ToSocketAddrs::to_socket_addrs
+#[cfg_attr(feature = "std", doc = "[`UdpSocket`]: std::net::UdpSocket")]
+#[cfg_attr(
+    not(feature = "std"),
+    doc = "[`UdpSocket`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html"
+)]
 ///
 pub trait ToSocketAddrs {
     /// Returned iterator over socket addresses which this type may correspond to.

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -12,9 +12,6 @@ use core::cmp::Ordering;
 /// This enum can contain either an [`Ipv4Addr`] or an [`Ipv6Addr`], see their
 /// respective documentation for more details.
 ///
-/// [`Ipv4Addr`]: ../../no-std-net/struct.Ipv4Addr.html
-/// [`Ipv6Addr`]: ../../no-std-net/struct.Ipv6Addr.html
-///
 /// # Examples
 ///
 /// ```
@@ -45,14 +42,13 @@ pub enum IpAddr {
 /// See [`IpAddr`] for a type encompassing both IPv4 and IPv6 addresses.
 ///
 /// [IETF RFC 791]: https://tools.ietf.org/html/rfc791
-/// [`IpAddr`]: ../../no-std-net/enum.IpAddr.html
 ///
 /// # Textual representation
 ///
 /// `Ipv4Addr` provides a [`FromStr`] implementation. The four octets are in decimal
 /// notation, divided by `.` (this is called "dot-decimal notation").
 ///
-/// [`FromStr`]: https://doc.rust-lang.org/core/str/trait.FromStr.html
+/// [`FromStr`]: core::str::FromStr
 ///
 /// # Examples
 ///
@@ -68,7 +64,6 @@ pub struct Ipv4Addr {
     // Octets stored in transmit order.
     inner: [u8; 4],
 }
-// TODO: clean up all the links in the documentation!
 
 /// An IPv6 address.
 ///
@@ -78,7 +73,6 @@ pub struct Ipv4Addr {
 /// See [`IpAddr`] for a type encompassing both IPv4 and IPv6 addresses.
 ///
 /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
-/// [`IpAddr`]: ../../no-std-net/enum.IpAddr.html
 ///
 /// # Textual representation
 ///
@@ -87,7 +81,7 @@ pub struct Ipv4Addr {
 /// notation, and segments are separated by `:`. For more information, see
 /// [IETF RFC 5952].
 ///
-/// [`FromStr`]: https://doc.rust-lang.org/core/str/trait.FromStr.html
+/// [`FromStr`]: core::str::FromStr
 /// [IETF RFC 5952]: https://tools.ietf.org/html/rfc5952
 ///
 /// # Examples
@@ -120,12 +114,8 @@ pub enum Ipv6MulticastScope {
 impl IpAddr {
     /// Returns [`true`] for the special 'unspecified' address.
     ///
-    /// See the documentation for [`Ipv4Addr::is_unspecified`][IPv4] and
-    /// [`Ipv6Addr::is_unspecified`][IPv6] for more details.
-    ///
-    /// [IPv4]: ../../no-std-net/struct.Ipv4Addr.html#method.is_unspecified
-    /// [IPv6]: ../../no-std-net/struct.Ipv6Addr.html#method.is_unspecified
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
+    /// See the documentation for [`Ipv4Addr::is_unspecified()`] and
+    /// [`Ipv6Addr::is_unspecified()`] for more details.
     ///
     /// # Examples
     ///
@@ -144,12 +134,8 @@ impl IpAddr {
 
     /// Returns [`true`] if this is a loopback address.
     ///
-    /// See the documentation for [`Ipv4Addr::is_loopback`][IPv4] and
-    /// [`Ipv6Addr::is_loopback`][IPv6] for more details.
-    ///
-    /// [IPv4]: ../../no-std-net/struct.Ipv4Addr.html#method.is_loopback
-    /// [IPv6]: ../../no-std-net/struct.Ipv6Addr.html#method.is_loopback
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
+    /// See the documentation for [`Ipv4Addr::is_loopback()`] and
+    /// [`Ipv6Addr::is_loopback()`] for more details.
     ///
     /// # Examples
     ///
@@ -168,12 +154,8 @@ impl IpAddr {
 
     /// Returns [`true`] if the address appears to be globally routable.
     ///
-    /// See the documentation for [`Ipv4Addr::is_global`][IPv4] and
-    /// [`Ipv6Addr::is_global`][IPv6] for more details.
-    ///
-    /// [IPv4]: ../../no-std-net/struct.Ipv4Addr.html#method.is_global
-    /// [IPv6]: ../../no-std-net/struct.Ipv6Addr.html#method.is_global
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
+    /// See the documentation for [`Ipv4Addr::is_global()`] and
+    /// [`Ipv6Addr::is_global()`] for more details.
     ///
     /// # Examples
     ///
@@ -195,12 +177,8 @@ impl IpAddr {
 
     /// Returns [`true`] if this is a multicast address.
     ///
-    /// See the documentation for [`Ipv4Addr::is_multicast`][IPv4] and
-    /// [`Ipv6Addr::is_multicast`][IPv6] for more details.
-    ///
-    /// [IPv4]: ../../no-std-net/struct.Ipv4Addr.html#method.is_multicast
-    /// [IPv6]: ../../no-std-net/struct.Ipv6Addr.html#method.is_multicast
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
+    /// See the documentation for [`Ipv4Addr::is_multicast()`] and
+    /// [`Ipv6Addr::is_multicast()`] for more details.
     ///
     /// # Examples
     ///
@@ -219,12 +197,8 @@ impl IpAddr {
 
     /// Returns [`true`] if this address is in a range designated for documentation.
     ///
-    /// See the documentation for [`Ipv4Addr::is_documentation`][IPv4] and
-    /// [`Ipv6Addr::is_documentation`][IPv6] for more details.
-    ///
-    /// [IPv4]: ../../no-std-net/struct.Ipv4Addr.html#method.is_documentation
-    /// [IPv6]: ../../no-std-net/struct.Ipv6Addr.html#method.is_documentation
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
+    /// See the documentation for [`Ipv4Addr::is_documentation()`] and
+    /// [`Ipv6Addr::is_documentation()`] for more details.
     ///
     /// # Examples
     ///
@@ -244,11 +218,10 @@ impl IpAddr {
         }
     }
 
-    /// Returns [`true`] if this address is an [IPv4 address], and [`false`] otherwise.
+    /// Returns [`true`] if this address is an [`IPv4` address], and [`false`]
+    /// otherwise.
     ///
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
-    /// [`false`]: https://doc.rust-lang.org/std/primitive.bool.html
-    /// [IPv4 address]: #variant.V4
+    /// [`IPv4` address]: IpAddr::V4
     ///
     /// # Examples
     ///
@@ -268,11 +241,10 @@ impl IpAddr {
         }
     }
 
-    /// Returns [`true`] if this address is an [IPv6 address], and [`false`] otherwise.
+    /// Returns [`true`] if this address is an [`IPv6` address], and [`false`]
+    /// otherwise.
     ///
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
-    /// [`false`]: https://doc.rust-lang.org/std/primitive.bool.html
-    /// [IPv6 address]: #variant.V6
+    /// [`IPv6` address]: IpAddr::V6
     ///
     /// # Examples
     ///
@@ -543,13 +515,12 @@ impl Ipv4Addr {
         [self.inner[0], self.inner[1], self.inner[2], self.inner[3]]
     }
 
-    /// Returns [`true`] for the special 'unspecified' address (0.0.0.0).
+    /// Returns [`true`] for the special 'unspecified' address (`0.0.0.0`).
     ///
     /// This property is defined in _UNIX Network Programming, Second Edition_,
     /// W. Richard Stevens, p. 891; see also [ip7].
     ///
     /// [ip7]: http://man7.org/linux/man-pages/man7/ip.7.html
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -563,12 +534,11 @@ impl Ipv4Addr {
         self.inner[0] == 0 && self.inner[1] == 0 && self.inner[2] == 0 && self.inner[3] == 0
     }
 
-    /// Returns [`true`] if this is a loopback address (127.0.0.0/8).
+    /// Returns [`true`] if this is a loopback address (`127.0.0.0/8`).
     ///
     /// This property is defined by [IETF RFC 1122].
     ///
     /// [IETF RFC 1122]: https://tools.ietf.org/html/rfc1122
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -586,12 +556,11 @@ impl Ipv4Addr {
     ///
     /// The private address ranges are defined in [IETF RFC 1918] and include:
     ///
-    ///  - 10.0.0.0/8
-    ///  - 172.16.0.0/12
-    ///  - 192.168.0.0/16
+    ///  - `10.0.0.0/8`
+    ///  - `172.16.0.0/12`
+    ///  - `192.168.0.0/16`
     ///
     /// [IETF RFC 1918]: https://tools.ietf.org/html/rfc1918
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -615,12 +584,11 @@ impl Ipv4Addr {
         }
     }
 
-    /// Returns [`true`] if the address is link-local (169.254.0.0/16).
+    /// Returns [`true`] if the address is link-local (`169.254.0.0/16`).
     ///
     /// This property is defined by [IETF RFC 3927].
     ///
     /// [IETF RFC 3927]: https://tools.ietf.org/html/rfc3927
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -638,7 +606,7 @@ impl Ipv4Addr {
     /// Returns [`true`] if the address appears to be globally routable.
     /// See [iana-ipv4-special-registry][ipv4-sr].
     ///
-    /// The following return false:
+    /// The following return [`false`]:
     ///
     /// - private address (10.0.0.0/8, 172.16.0.0/12 and 192.168.0.0/16)
     /// - the loopback address (127.0.0.0/8)
@@ -648,7 +616,6 @@ impl Ipv4Addr {
     /// - the unspecified address (0.0.0.0)
     ///
     /// [ipv4-sr]: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -678,7 +645,6 @@ impl Ipv4Addr {
     /// and is defined by [IETF RFC 5771].
     ///
     /// [IETF RFC 5771]: https://tools.ietf.org/html/rfc5771
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -698,7 +664,6 @@ impl Ipv4Addr {
     /// A broadcast address has all octets set to 255 as defined in [IETF RFC 919].
     ///
     /// [IETF RFC 919]: https://tools.ietf.org/html/rfc919
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -721,7 +686,6 @@ impl Ipv4Addr {
     /// - 203.0.113.0/24 (TEST-NET-3)
     ///
     /// [IETF RFC 5737]: https://tools.ietf.org/html/rfc5737
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -746,7 +710,7 @@ impl Ipv4Addr {
     ///
     /// a.b.c.d becomes ::a.b.c.d
     ///
-    /// [IPv6 address]: ../../no-std-net/struct.Ipv6Addr.html
+    /// [IPv6 address]: Ipv6Addr
     ///
     /// # Examples
     ///
@@ -773,7 +737,7 @@ impl Ipv4Addr {
     ///
     /// a.b.c.d becomes ::ffff:a.b.c.d
     ///
-    /// [IPv6 address]: ../../no-std-net/struct.Ipv6Addr.html
+    /// [IPv6 address]: Ipv6Addr
     ///
     /// # Examples
     ///
@@ -981,7 +945,6 @@ impl Ipv6Addr {
     /// This property is defined in [IETF RFC 4291].
     ///
     /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1007,7 +970,6 @@ impl Ipv6Addr {
     /// This property is defined in [IETF RFC 4291].
     ///
     /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1037,9 +999,6 @@ impl Ipv6Addr {
     /// - link-local, site-local, and unique local unicast addresses
     /// - interface-, link-, realm-, admin- and site-local multicast addresses
     ///
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
-    /// [`false`]: https://doc.rust-lang.org/std/primitive.bool.html
-    ///
     /// # Examples
     ///
     /// ```
@@ -1064,7 +1023,6 @@ impl Ipv6Addr {
     /// This property is defined in [IETF RFC 4193].
     ///
     /// [IETF RFC 4193]: https://tools.ietf.org/html/rfc4193
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1086,7 +1044,6 @@ impl Ipv6Addr {
     /// This property is defined in [IETF RFC 4291].
     ///
     /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1105,8 +1062,6 @@ impl Ipv6Addr {
 
     /// Returns [`true`] if this is a deprecated unicast site-local address
     /// (fec0::/10).
-    ///
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1129,7 +1084,6 @@ impl Ipv6Addr {
     /// This property is defined in [IETF RFC 3849].
     ///
     /// [IETF RFC 3849]: https://tools.ietf.org/html/rfc3849
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1156,8 +1110,6 @@ impl Ipv6Addr {
     /// - unique local addresses
     /// - the unspecified address
     /// - the address range reserved for documentation
-    ///
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1215,7 +1167,6 @@ impl Ipv6Addr {
     /// This property is defined by [IETF RFC 4291].
     ///
     /// [IETF RFC 4291]: https://tools.ietf.org/html/rfc4291
-    /// [`true`]: https://doc.rust-lang.org/std/primitive.bool.html
     ///
     /// # Examples
     ///
@@ -1234,8 +1185,7 @@ impl Ipv6Addr {
     ///
     /// ::a.b.c.d and ::ffff:a.b.c.d become a.b.c.d
     ///
-    /// [IPv4 address]: ../../no-std-net/struct.Ipv4Addr.html
-    /// [`None`]: https://doc.rust-lang.org/core/option/enum.Option.html#variant.None
+    /// [IPv4 address]: Ipv4Addr
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,19 +23,21 @@
 //!   with networking objects like [`TcpListener`], [`TcpStream`] or [`UdpSocket`]
 //! * Other types are return or parameter types for various methods in this module
 //!
-//! [`IpAddr`]: ../../no-std-net/enum.IpAddr.html
-//! [`Ipv4Addr`]: ../../no-std-net/struct.Ipv4Addr.html
-//! [`Ipv6Addr`]: ../../no-std-net/struct.Ipv6Addr.html
-//! [`SocketAddr`]: ../../std/net/enum.SocketAddr.html
-//! [`SocketAddrV4`]: ../../std/net/struct.SocketAddrV4.html
-//! [`SocketAddrV6`]: ../../std/net/struct.SocketAddrV6.html
-//! [`TcpListener`]: ../../std/net/struct.TcpListener.html
-//! [`TcpStream`]: ../../std/net/struct.TcpStream.html
-//! [`ToSocketAddrs`]: ../../std/net/trait.ToSocketAddrs.html
-//! [`UdpSocket`]: ../../std/net/struct.UdpSocket.html
-
-// TODO: figure out how to put links into rustdocs and update the above
-
+#![cfg_attr(feature = "std", doc = "[`TcpListener`]: std::net::TcpListener")]
+#![cfg_attr(feature = "std", doc = "[`TcpStream`]: std::net::TcpStream")]
+#![cfg_attr(feature = "std", doc = "[`UdpSocket`]: std::net::UdpSocket")]
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`TcpListener`]: https://doc.rust-lang.org/std/net/struct.TcpListener.html"
+)]
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`TcpStream`]: https://doc.rust-lang.org/std/net/struct.TcpStream.html"
+)]
+#![cfg_attr(
+    not(feature = "std"),
+    doc = "[`UdpSocket`]: https://doc.rust-lang.org/std/net/struct.UdpSocket.html"
+)]
 #![no_std]
 #![deny(
 	dead_code,
@@ -47,6 +49,9 @@
 	warnings,
 )]
 #![forbid(unsafe_code)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 use core::fmt;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -358,14 +358,6 @@ impl FromStr for SocketAddr {
 /// // No problem, the `panic!` message has disappeared.
 /// let _foo: SocketAddr = "127.0.0.1:8080".parse().expect("unreachable panic");
 /// ```
-///
-/// [`FromStr`]: ../../std/str/trait.FromStr.html
-/// [`IpAddr`]: ../../no-std-net/enum.IpAddr.html
-/// [`Ipv4Addr`]: ../../no-std-net/struct.Ipv4Addr.html
-/// [`Ipv6Addr`]: ../../no-std-net/struct.Ipv6Addr.html
-/// [`SocketAddr`]: ../../no-std-net/enum.SocketAddr.html
-/// [`SocketAddrV4`]: ../../no-std-net/struct.SocketAddrV4.html
-/// [`SocketAddrV6`]: ../../no-std-net/struct.SocketAddrV6.html
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddrParseError(());
 


### PR DESCRIPTION
Use intra-doc links to fix documentation.

Had to add a new feature `std` which is used to properly link to the `std::net` documentation.

See https://github.com/rust-lang/rust/issues/76252 for a bit of background on why this is tedious.